### PR TITLE
feat: Add Memgraph DR backup container, retention, and identity

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -245,6 +245,12 @@ module "clickhouse_backup" {
   storage_private_endpoint_name_override    = var.storage_private_endpoint_name_override
   storage_dns_link_name_override            = var.storage_dns_link_name_override
   backup_lifecycle_expiration_days          = var.backup_lifecycle_expiration_days
+
+  # Memgraph DR backups (shares this storage account; retention rules must live
+  # in the submodule's single management policy)
+  memgraph_backup_enabled                   = var.memgraph_backup_enabled
+  memgraph_backup_container_name_override   = var.memgraph_backup_container_name_override
+  memgraph_backup_lifecycle_expiration_days = var.memgraph_backup_lifecycle_expiration_days
 }
 
 module "data_lake" {
@@ -293,7 +299,25 @@ locals {
     }
   } : {}
 
-  merged_service_accounts = merge(var.service_accounts, local.temporal_postgres_pod_service_account)
+  # The app's nightly Memgraph backup job runs in the worker pods and uploads
+  # snapshots to the memgraph-backup container on the shared storage account.
+  memgraph_backup_worker_service_account = var.memgraph_backup_enabled ? {
+    (var.memgraph_backup_service_account_name) = {
+      namespace             = var.memgraph_backup_service_account_namespace != "" ? var.memgraph_backup_service_account_namespace : var.deployment_name
+      create_azure_identity = true
+      identity_name         = "datafold-memgraph-backup"
+      role_assignments = [{
+        role  = "Storage Blob Data Contributor"
+        scope = module.clickhouse_backup.storage_account_id
+      }]
+    }
+  } : {}
+
+  merged_service_accounts = merge(
+    var.service_accounts,
+    local.temporal_postgres_pod_service_account,
+    local.memgraph_backup_worker_service_account,
+  )
 }
 
 module "aks" {

--- a/modules/clickhouse_backup/main.tf
+++ b/modules/clickhouse_backup/main.tf
@@ -1,9 +1,10 @@
 locals {
-  storage_account_name          = var.storage_account_name_override != "" ? var.storage_account_name_override : replace("${var.deployment_name}-storage", "-", "")
+  storage_account_name             = var.storage_account_name_override != "" ? var.storage_account_name_override : replace("${var.deployment_name}-storage", "-", "")
   clickhouse_backup_container_name = var.clickhouse_backup_container_name_override != "" ? var.clickhouse_backup_container_name_override : "${var.deployment_name}-clickhouse-backup"
-  storage_private_dns_zone_name = var.storage_private_dns_zone_name_override != "" ? var.storage_private_dns_zone_name_override : "privatelink.blob.core.windows.net"
-  storage_private_endpoint_name = var.storage_private_endpoint_name_override != "" ? var.storage_private_endpoint_name_override : "${var.deployment_name}-pe-storage"
-  storage_dns_link_name        = var.storage_dns_link_name_override != "" ? var.storage_dns_link_name_override : "link-privateDnsZone-to-vnet"
+  memgraph_backup_container_name   = var.memgraph_backup_container_name_override != "" ? var.memgraph_backup_container_name_override : "${var.deployment_name}-memgraph-backup"
+  storage_private_dns_zone_name    = var.storage_private_dns_zone_name_override != "" ? var.storage_private_dns_zone_name_override : "privatelink.blob.core.windows.net"
+  storage_private_endpoint_name    = var.storage_private_endpoint_name_override != "" ? var.storage_private_endpoint_name_override : "${var.deployment_name}-pe-storage"
+  storage_dns_link_name            = var.storage_dns_link_name_override != "" ? var.storage_dns_link_name_override : "link-privateDnsZone-to-vnet"
 }
 
 resource "azurerm_storage_account" "storage" {
@@ -21,11 +22,27 @@ resource "azurerm_storage_account" "storage" {
 }
 
 resource "azurerm_storage_container" "clickhouse_backup" {
-  name                 = local.clickhouse_backup_container_name
-  storage_account_id   = azurerm_storage_account.storage.id
+  name                  = local.clickhouse_backup_container_name
+  storage_account_id    = azurerm_storage_account.storage.id
   container_access_type = "private"
 }
 
+# Memgraph DR backups (datafold repo: docs/decisions/choose-memgraph-dr-architecture.md).
+# The nightly backup job in the app uploads each graph's newest snapshot here;
+# the lifecycle rule below is the entire retention policy (the app never prunes).
+resource "azurerm_storage_container" "memgraph_backup" {
+  count = var.memgraph_backup_enabled ? 1 : 0
+
+  name                  = local.memgraph_backup_container_name
+  storage_account_id    = azurerm_storage_account.storage.id
+  container_access_type = "private"
+}
+
+# Azure allows exactly ONE management policy resource per storage account — it
+# owns the account's whole lifecycle document. Every retention rule for this
+# account must therefore live in this resource; a second
+# azurerm_storage_management_policy anywhere (another module, a deployment dir)
+# would silently wipe these rules on each alternating apply.
 resource "azurerm_storage_management_policy" "clickhouse_backup" {
   storage_account_id = azurerm_storage_account.storage.id
 
@@ -39,6 +56,23 @@ resource "azurerm_storage_management_policy" "clickhouse_backup" {
     actions {
       base_blob {
         delete_after_days_since_modification_greater_than = var.backup_lifecycle_expiration_days
+      }
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.memgraph_backup_enabled ? [1] : []
+    content {
+      name    = "memgraph_backup_retention"
+      enabled = true
+      filters {
+        blob_types   = ["blockBlob"]
+        prefix_match = [local.memgraph_backup_container_name]
+      }
+      actions {
+        base_blob {
+          delete_after_days_since_modification_greater_than = var.memgraph_backup_lifecycle_expiration_days
+        }
       }
     }
   }

--- a/modules/clickhouse_backup/outputs.tf
+++ b/modules/clickhouse_backup/outputs.tf
@@ -9,3 +9,11 @@ output "azure_blob_account_key" {
 output "azure_blob_container" {
   value = azurerm_storage_container.clickhouse_backup.name
 }
+
+output "storage_account_id" {
+  value = azurerm_storage_account.storage.id
+}
+
+output "memgraph_backup_container" {
+  value = var.memgraph_backup_enabled ? azurerm_storage_container.memgraph_backup[0].name : null
+}

--- a/modules/clickhouse_backup/variables.tf
+++ b/modules/clickhouse_backup/variables.tf
@@ -73,3 +73,25 @@ variable "backup_lifecycle_expiration_days" {
   default     = 6
   description = "Number of days after which clickhouse backup objects will expire and be deleted."
 }
+
+# ┏┳┓┏━╸┏┳┓┏━╸┏━┓┏━┓┏━┓╻ ╻   ┏┓ ┏━┓┏━╸╻┏ ╻ ╻┏━┓
+# ┃┃┃┣╸ ┃┃┃┃╺┓┣┳┛┣━┫┣━┛┣━┫   ┣┻┓┣━┫┃  ┣┻┓┃ ┃┣━┛
+# ╹ ╹┗━╸╹ ╹┗━┛╹┗╸╹ ╹╹  ╹ ╹   ┗━┛╹ ╹┗━╸╹┗╸┗━┛╹
+
+variable "memgraph_backup_enabled" {
+  type        = bool
+  default     = false
+  description = "Create the Memgraph DR backup container and its lifecycle retention rule on the storage account."
+}
+
+variable "memgraph_backup_container_name_override" {
+  description = "Override for the name used in resource.azurerm_storage_container.memgraph_backup"
+  type        = string
+  default     = ""
+}
+
+variable "memgraph_backup_lifecycle_expiration_days" {
+  type        = number
+  default     = 30
+  description = "Number of days after which memgraph backup objects will expire and be deleted."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -626,6 +626,37 @@ variable "backup_lifecycle_expiration_days" {
   description = "Number of days after which clickhouse backup objects will expire and be deleted."
 }
 
+# Memgraph DR Backup (shares the clickhouse_backup storage account)
+variable "memgraph_backup_enabled" {
+  type        = bool
+  default     = false
+  description = "Create the Memgraph DR backup container, its lifecycle retention rule, and a workload identity for the worker service account."
+}
+
+variable "memgraph_backup_container_name_override" {
+  description = "Override for the name used in resource.azurerm_storage_container.memgraph_backup (modules/clickhouse_backup)"
+  type        = string
+  default     = ""
+}
+
+variable "memgraph_backup_lifecycle_expiration_days" {
+  type        = number
+  default     = 30
+  description = "Number of days after which memgraph backup objects will expire and be deleted."
+}
+
+variable "memgraph_backup_service_account_name" {
+  type        = string
+  default     = "worker"
+  description = "Kubernetes service account (running the app's backup job) that gets Storage Blob Data Contributor on the storage account."
+}
+
+variable "memgraph_backup_service_account_namespace" {
+  type        = string
+  default     = ""
+  description = "Namespace of the memgraph backup service account. Empty = the deployment name."
+}
+
 # Key Vault Module Overrides
 variable "key_vault_name_override" {
   description = "Override for the name used in resource.azurerm_key_vault.default (modules/key_vault)"


### PR DESCRIPTION
## Summary

Memgraph DR backups (ENG-4100; datafold repo `docs/decisions/choose-memgraph-dr-architecture.md`; consumers: datafold/cloud-infra#1361) need a blob container + 30-day lifecycle retention on the shared `{deployment}storage` account, plus a workload identity for the worker SA that uploads snapshots.

The retention rule **must** live in this module: Azure allows exactly one `azurerm_storage_management_policy` per storage account (it owns the whole lifecycle document), and this module's `clickhouse_backup` policy already owns it (rule `backup_retention`). Cursor Bugbot caught cloud-infra#1361 declaring a second policy resource at the deployment level — the two states would have alternately wiped each other's rules (ClickHouse retention included). This PR is the structural fix.

Everything is opt-in behind `memgraph_backup_enabled` (default false — **no change for existing deployments until they set it**):

- `azurerm_storage_container.memgraph_backup` (default name `{deployment}-memgraph-backup`, override variable provided)
- `dynamic "rule" memgraph_backup_retention` inside the existing management policy, `memgraph_backup_lifecycle_expiration_days` (default 30)
- workload identity `datafold-memgraph-backup` for `memgraph_backup_service_account_name` (default `worker`) with Storage Blob Data Contributor on the account — merged into `service_accounts` following the temporal `postgres-pod` pattern
- new `clickhouse_backup` outputs: `storage_account_id`, `memgraph_backup_container`

No new private endpoint/DNS — the account-level blob PE already covers the new container.

## Validation

`terraform fmt` + `terraform validate` (init -backend=false) clean. Expected plan on ecolab with `memgraph_backup_enabled = true`: +1 container, in-place policy update **adding** `memgraph_backup_retention` while **keeping** `backup_retention` (please verify both rules appear in the plan diff), +1 identity/federated-credential/role-assignment, 0 destroys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)